### PR TITLE
Add Playwright fixtures for deterministic mocked Letta

### DIFF
--- a/swarms-web/app.py
+++ b/swarms-web/app.py
@@ -30,6 +30,8 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from letta_client import Letta
 from letta_flask import LettaFlask, LettaFlaskConfig
 
+from playwright_fixtures import get_mock_agents
+
 from spds import config
 from spds.export_manager import ExportManager, export_session_to_json, export_session_to_markdown
 from spds.secretary_agent import SecretaryAgent
@@ -647,6 +649,9 @@ def chat():
 @app.route("/api/agents")
 def get_agents():
     """API endpoint to get available agents."""
+    if os.getenv("PLAYWRIGHT_TEST") == "1":
+        return jsonify({"agents": get_mock_agents()})
+
     try:
         # Initialize Letta client
         letta_password = config.get_letta_password()

--- a/swarms-web/playwright_fixtures.py
+++ b/swarms-web/playwright_fixtures.py
@@ -1,0 +1,76 @@
+"""Utilities for deterministic Playwright fixtures used in test mode."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List
+
+_DATA_PATH = Path(__file__).resolve().parent / 'tests' / 'e2e' / 'mock-data.json'
+
+def _load_fixture_payload() -> Dict[str, Any]:
+    try:
+        with _DATA_PATH.open('r', encoding='utf-8') as handle:
+            payload = json.load(handle)
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError:
+        return {}
+
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+@lru_cache(maxsize=1)
+def _get_cached_payload() -> Dict[str, Any]:
+    payload = _load_fixture_payload()
+
+    agents = payload.get('agents')
+    if not isinstance(agents, list):
+        agents = []
+
+    normalized_agents: List[Dict[str, str]] = []
+    for index, agent in enumerate(agents):
+        if not isinstance(agent, dict):
+            continue
+
+        def _string_or(default: str, value: Any) -> str:
+            return value if isinstance(value, str) else default
+
+        normalized_agents.append(
+            {
+                'id': _string_or(f'mock-agent-{index + 1}', agent.get('id')),
+                'name': _string_or(f'Mock Agent {index + 1}', agent.get('name')),
+                'model': _string_or('openai/gpt-4', agent.get('model')),
+                'created_at': _string_or('2024-01-01', agent.get('created_at')),
+            }
+        )
+
+    secretary_minutes = payload.get('secretaryMinutes')
+    agent_response = payload.get('agentResponse')
+
+    return {
+        'agents': normalized_agents,
+        'secretary_minutes': secretary_minutes if isinstance(secretary_minutes, str) else '',
+        'agent_response': agent_response if isinstance(agent_response, str) else '',
+    }
+
+
+def get_mock_agents() -> List[Dict[str, str]]:
+    """Return deterministic agent metadata for Playwright tests."""
+
+    return [dict(agent) for agent in _get_cached_payload()['agents']]
+
+
+def get_secretary_minutes() -> str:
+    """Return the deterministic secretary minutes string for Playwright tests."""
+
+    return _get_cached_payload()['secretary_minutes']
+
+
+def get_agent_response() -> str:
+    """Return the deterministic agent response text for Playwright tests."""
+
+    return _get_cached_payload()['agent_response']

--- a/swarms-web/tests/e2e/conversation.spec.ts
+++ b/swarms-web/tests/e2e/conversation.spec.ts
@@ -1,259 +1,4 @@
-import { expect, test, Page } from '@playwright/test';
-
-type MockAgent = {
-  id: string;
-  name: string;
-  model: string;
-  created_at: string;
-};
-
-const mockAgents: MockAgent[] = [
-  {
-    id: 'agent-1',
-    name: 'Alex Johnson',
-    model: 'openai/gpt-4',
-    created_at: '2024-01-01',
-  },
-  {
-    id: 'agent-2',
-    name: 'Jordan Smith',
-    model: 'anthropic/claude-3',
-    created_at: '2024-01-02',
-  },
-  {
-    id: 'agent-3',
-    name: 'Casey Lee',
-    model: 'openai/gpt-4',
-    created_at: '2024-01-03',
-  },
-];
-
-let currentAgents: MockAgent[] = [...mockAgents];
-
-test.beforeEach(async ({ page }) => {
-  currentAgents = [...mockAgents];
-
-  await page.addInitScript(({ agents }) => {
-    const mockAgentsData = agents as MockAgent[];
-
-    class BootstrapToastStub {
-      element: HTMLElement;
-
-      constructor(element: HTMLElement) {
-        this.element = element;
-        setTimeout(() => {
-          const shownEvent = new CustomEvent('shown.bs.toast');
-          this.element.dispatchEvent(shownEvent);
-        }, 0);
-      }
-
-      show() {
-        setTimeout(() => {
-          const hiddenEvent = new CustomEvent('hidden.bs.toast');
-          this.element.dispatchEvent(hiddenEvent);
-        }, 1500);
-      }
-    }
-
-    const ensureBootstrap = () => {
-      const win = window as typeof window & {
-        bootstrap?: { Toast: typeof BootstrapToastStub };
-      };
-      if (!win.bootstrap) {
-        win.bootstrap = { Toast: BootstrapToastStub };
-      }
-    };
-
-    const createSocketFactory = () => {
-      let socket: {
-        on: (event: string, callback: (payload?: unknown) => void) => typeof socket;
-        off: (event?: string) => typeof socket;
-        emit: (event: string, payload?: Record<string, unknown>) => typeof socket;
-        disconnect: () => void;
-      } | null = null;
-
-      const factory = () => {
-        if (socket) {
-          return socket;
-        }
-
-        const listeners = new Map<string, ((payload?: unknown) => void)[]>();
-
-        const ensureListeners = (event: string) => {
-          if (!listeners.has(event)) {
-            listeners.set(event, []);
-          }
-          return listeners.get(event)!;
-        };
-
-        const emitEvent = (event: string, payload?: unknown) => {
-          const handlers = listeners.get(event);
-          if (!handlers) {
-            return;
-          }
-          handlers.forEach((handler) => {
-            try {
-              handler(payload);
-            } catch (error) {
-              console.error('Mock socket handler error', error);
-            }
-          });
-        };
-
-        const socketInstance = {
-          on(event: string, callback: (payload?: unknown) => void) {
-            ensureListeners(event).push(callback);
-            if (event === 'connect') {
-              setTimeout(() => callback(undefined), 0);
-            }
-            return socketInstance;
-          },
-          off(event?: string) {
-            if (!event) {
-              listeners.clear();
-            } else {
-              listeners.delete(event);
-            }
-            return socketInstance;
-          },
-          emit(event: string, payload?: Record<string, unknown>) {
-            if (event === 'join_session' && payload?.session_id) {
-              setTimeout(() => emitEvent('joined', { session_id: payload.session_id }), 0);
-            }
-
-            if (event === 'start_chat' && payload?.topic) {
-              setTimeout(() => {
-                emitEvent('chat_started', {
-                  topic: payload.topic,
-                  mode: 'hybrid',
-                  agents: mockAgentsData.map((agent) => ({ name: agent.name, id: agent.id })),
-                  secretary_enabled: true,
-                });
-              }, 50);
-            }
-
-            if (event === 'user_message' && typeof payload?.message === 'string') {
-              const message = payload.message;
-              const timestamp = new Date().toISOString();
-
-              setTimeout(() => {
-                emitEvent('user_message', {
-                  speaker: 'You',
-                  message,
-                  timestamp,
-                });
-              }, 0);
-
-              const trimmedMessage = message.trim();
-              if (trimmedMessage.startsWith('/')) {
-                if (trimmedMessage === '/minutes') {
-                  setTimeout(() => {
-                    const minutesContainer = document.getElementById('secretary-minutes');
-                    if (minutesContainer) {
-                      minutesContainer.style.display = 'block';
-                    }
-                    emitEvent('secretary_activity', {
-                      activity: 'generating',
-                      message: '📝 Generating meeting minutes...',
-                    });
-                    emitEvent('secretary_minutes', {
-                      minutes: 'Meeting Minutes\n- Agenda review\n- Decisions recorded',
-                    });
-                    emitEvent('secretary_activity', {
-                      activity: 'completed',
-                      message: '✅ Meeting minutes generated!',
-                    });
-                  }, 120);
-                }
-              } else {
-                setTimeout(() => {
-                  emitEvent('agent_message', {
-                    speaker: mockAgentsData[0]?.name || 'Agent',
-                    message: 'AI advancements look promising with collaborative intelligence.',
-                    timestamp: new Date().toISOString(),
-                    phase: 'response',
-                  });
-                }, 150);
-              }
-            }
-
-            return socketInstance;
-          },
-          disconnect() {
-            listeners.clear();
-          },
-        };
-
-        socket = socketInstance;
-        return socketInstance;
-      };
-
-      return factory;
-    };
-
-    ensureBootstrap();
-
-    const win = window as typeof window & {
-      __playwrightCreateSocketIO?: () => () => unknown;
-      io?: () => unknown;
-      __PLAYWRIGHT_TEST?: string;
-    };
-
-    win.__playwrightCreateSocketIO = createSocketFactory;
-    const socketFactory = createSocketFactory();
-    win.io = () => socketFactory();
-  }, { agents: mockAgents });
-
-  await page.route('**/socket.io.min.js*', async (route) => {
-    await route.fulfill({
-      contentType: 'application/javascript',
-      body: 'window.io = window.io || (window.__playwrightCreateSocketIO && window.__playwrightCreateSocketIO());',
-    });
-  });
-
-  await page.route('**/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js*', async (route) => {
-    await route.fulfill({
-      contentType: 'application/javascript',
-      body: 'window.bootstrap = window.bootstrap || { Toast: function ToastStub(){ this.show = function(){}; } };',
-    });
-  });
-
-  await page.route('**/api/agents', async (route) => {
-    await route.fulfill({
-      contentType: 'application/json',
-      body: JSON.stringify({ agents: currentAgents }),
-    });
-  });
-
-  // Inject a browser-global flag and set sessionStorage early to avoid
-  // evaluate/navigation races. Harmless when running locally.
-  await page.addInitScript(() => {
-    (window as any).__PLAYWRIGHT_TEST = '1';
-    try {
-      sessionStorage.setItem('sessionId', 'session-test');
-    } catch (e) {
-      // ignore
-    }
-  });
-});
-
-const startConversation = async (page: Page, topic = 'Exploring AI collaboration') => {
-  await page.goto('/setup');
-
-  const agentCards = page.locator('.agent-card');
-  await expect(agentCards.first()).toBeVisible();
-
-  await agentCards.nth(0).locator('input.agent-checkbox').check();
-  await agentCards.nth(1).locator('input.agent-checkbox').check();
-
-  await page.locator('.mode-card').first().click();
-  await page.locator('#topic').fill(topic);
-
-  await page.locator('#start-chat-btn').click();
-
-  await page.waitForResponse('**/api/start_session');
-  await expect(page.locator('#chat-input')).toBeVisible();
-};
+import { expect, test } from './fixtures.js';
 
 test('should load the main page and display agent selection cards', async ({ page }) => {
   await page.goto('/setup');
@@ -262,22 +7,27 @@ test('should load the main page and display agent selection cards', async ({ pag
   await expect(page.locator('.agent-card').first()).toBeVisible();
 });
 
-test('should allow a user to select agents, start a chat, and see agent responses', async ({ page }) => {
-  await startConversation(page, 'The future of AI collaboration');
+test(
+  'should allow a user to select agents, start a chat, and see agent responses',
+  async ({ page, startConversation }) => {
+    await startConversation('The future of AI collaboration');
 
-  await page.locator('#chat-input').fill('What is the future of AI?');
-  await page.locator('#send-button').click();
+    await page.locator('#chat-input').fill('What is the future of AI?');
+    await page.locator('#send-button').click();
 
-  const userMessage = page.locator('#chat-messages .message.user').filter({ hasText: 'What is the future of AI?' });
-  await expect(userMessage).toHaveCount(1);
+    const userMessage = page
+      .locator('#chat-messages .message.user')
+      .filter({ hasText: 'What is the future of AI?' });
+    await expect(userMessage).toHaveCount(1);
 
-  const agentMessage = page.locator('#chat-messages .message.agent').first();
-  await expect(agentMessage).toBeVisible();
-  await expect(agentMessage.locator('.message-content')).not.toHaveText(/^\s*$/);
-});
+    const agentMessage = page.locator('#chat-messages .message.agent').first();
+    await expect(agentMessage).toBeVisible();
+    await expect(agentMessage.locator('.message-content')).not.toHaveText(/^\s*$/);
+  }
+);
 
-test('should respond to the /minutes slash command', async ({ page }) => {
-  await startConversation(page, 'Documenting project updates');
+test('should respond to the /minutes slash command', async ({ page, startConversation }) => {
+  await startConversation('Documenting project updates');
 
   await page.locator('#chat-input').fill('/minutes');
   await page.locator('#send-button').click();
@@ -329,8 +79,8 @@ test('should update conversation mode selection when cards are changed', async (
   await expect(modeInput).toHaveValue('all_speak');
 });
 
-test('should show a warning when no agents are returned from the server', async ({ page }) => {
-  currentAgents = [];
+test('should show a warning when no agents are returned from the server', async ({ page, mockedLetta }) => {
+  await mockedLetta.setAgents([]);
   await page.goto('/setup');
 
   const noAgentsAlert = page.locator('#no-agents');

--- a/swarms-web/tests/e2e/fixtures.ts
+++ b/swarms-web/tests/e2e/fixtures.ts
@@ -1,0 +1,130 @@
+import { APIRequestContext, expect, test as base } from '@playwright/test';
+
+import { MockedLettaController } from './mockedLetta.js';
+import { MockAgent } from './mockData.js';
+
+type SessionSummary = {
+  id: string;
+  created_at: string;
+  last_updated: string;
+  title: string | null;
+  tags: string[];
+};
+
+type CreateSessionPayload = {
+  title?: string | null;
+  tags?: string[];
+};
+
+type SessionExport = {
+  filename: string;
+  size_bytes: number;
+  created_at: string;
+  kind: 'json' | 'markdown';
+};
+
+type CreateExportResponse = {
+  ok: boolean;
+  created?: { filename: string; kind: 'json' | 'markdown' }[];
+  error?: string;
+};
+
+type CreateSessionFn = (overrides?: CreateSessionPayload) => Promise<SessionSummary>;
+type ListSessionsFn = (options?: { limit?: number }) => Promise<SessionSummary[]>;
+type CreateSessionExportFn = (sessionId: string) => Promise<CreateExportResponse>;
+type ListSessionExportsFn = (sessionId: string, options?: { limit?: number }) => Promise<SessionExport[]>;
+
+const defaultSessionPayload = (): Required<CreateSessionPayload> => ({
+  title: 'Playwright Session',
+  tags: ['playwright'],
+});
+
+async function createSessionViaApi(
+  request: APIRequestContext,
+  overrides: CreateSessionPayload | undefined
+): Promise<SessionSummary> {
+  const payload = { ...defaultSessionPayload(), ...overrides };
+  const response = await request.post('/api/sessions', { data: payload });
+  expect(response.ok()).toBeTruthy();
+  return (await response.json()) as SessionSummary;
+}
+
+async function listSessionsViaApi(
+  request: APIRequestContext,
+  options?: { limit?: number }
+): Promise<SessionSummary[]> {
+  const params = new URLSearchParams();
+  if (options?.limit !== undefined) {
+    params.set('limit', String(options.limit));
+  }
+  const query = params.toString();
+  const response = await request.get(`/api/sessions${query ? `?${query}` : ''}`);
+  expect(response.ok()).toBeTruthy();
+  return (await response.json()) as SessionSummary[];
+}
+
+async function createSessionExportViaApi(
+  request: APIRequestContext,
+  sessionId: string
+): Promise<CreateExportResponse> {
+  const response = await request.post(`/api/sessions/${sessionId}/export`);
+  expect(response.ok()).toBeTruthy();
+  return (await response.json()) as CreateExportResponse;
+}
+
+async function listSessionExportsViaApi(
+  request: APIRequestContext,
+  sessionId: string,
+  options?: { limit?: number }
+): Promise<SessionExport[]> {
+  const params = new URLSearchParams();
+  if (options?.limit !== undefined) {
+    params.set('limit', String(options.limit));
+  }
+  const query = params.toString();
+  const response = await request.get(
+    `/api/sessions/${sessionId}/exports${query ? `?${query}` : ''}`
+  );
+  expect(response.ok()).toBeTruthy();
+  return (await response.json()) as SessionExport[];
+}
+
+export const test = base.extend<{
+  mockedLetta: MockedLettaController;
+  startConversation: (topic?: string) => Promise<void>;
+  createSession: CreateSessionFn;
+  listSessions: ListSessionsFn;
+  createSessionExport: CreateSessionExportFn;
+  listSessionExports: ListSessionExportsFn;
+  setAgents: (agents: MockAgent[]) => Promise<void>;
+}>(
+  {
+    mockedLetta: async ({ page }, use) => {
+      const controller = new MockedLettaController(page);
+      await controller.init();
+      await controller.reset();
+      await use(controller);
+      await controller.dispose();
+    },
+    startConversation: async ({ mockedLetta }, use) => {
+      await use((topic) => mockedLetta.startConversation(topic));
+    },
+    createSession: async ({ request }, use) => {
+      await use((overrides) => createSessionViaApi(request, overrides));
+    },
+    listSessions: async ({ request }, use) => {
+      await use((options) => listSessionsViaApi(request, options));
+    },
+    createSessionExport: async ({ request }, use) => {
+      await use((sessionId) => createSessionExportViaApi(request, sessionId));
+    },
+    listSessionExports: async ({ request }, use) => {
+      await use((sessionId, options) => listSessionExportsViaApi(request, sessionId, options));
+    },
+    setAgents: async ({ mockedLetta }, use) => {
+      await use((agents) => mockedLetta.setAgents(agents));
+    },
+  }
+);
+
+export { expect } from '@playwright/test';

--- a/swarms-web/tests/e2e/mock-data.json
+++ b/swarms-web/tests/e2e/mock-data.json
@@ -1,0 +1,24 @@
+{
+  "agents": [
+    {
+      "id": "agent-1",
+      "name": "Alex Johnson",
+      "model": "openai/gpt-4",
+      "created_at": "2024-01-01"
+    },
+    {
+      "id": "agent-2",
+      "name": "Jordan Smith",
+      "model": "anthropic/claude-3",
+      "created_at": "2024-01-02"
+    },
+    {
+      "id": "agent-3",
+      "name": "Casey Lee",
+      "model": "openai/gpt-4",
+      "created_at": "2024-01-03"
+    }
+  ],
+  "secretaryMinutes": "Meeting Minutes\n- Agenda review\n- Decisions recorded",
+  "agentResponse": "AI advancements look promising with collaborative intelligence."
+}

--- a/swarms-web/tests/e2e/mockData.ts
+++ b/swarms-web/tests/e2e/mockData.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+export type MockAgent = {
+  id: string;
+  name: string;
+  model: string;
+  created_at: string;
+};
+
+type MockData = {
+  agents: MockAgent[];
+  secretaryMinutes: string;
+  agentResponse: string;
+};
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const mockDataPath = path.resolve(currentDir, './mock-data.json');
+
+const raw = readFileSync(mockDataPath, 'utf-8');
+const parsed = JSON.parse(raw) as Partial<MockData>;
+
+const normalizeAgents = (agents: unknown): MockAgent[] => {
+  if (!Array.isArray(agents)) {
+    return [];
+  }
+
+  return agents
+    .map((agent, index) => {
+      if (typeof agent !== 'object' || agent === null) {
+        return null;
+      }
+
+      const candidate = agent as Record<string, unknown>;
+      return {
+        id: typeof candidate.id === 'string' ? candidate.id : `mock-agent-${index + 1}`,
+        name: typeof candidate.name === 'string' ? candidate.name : `Mock Agent ${index + 1}`,
+        model: typeof candidate.model === 'string' ? candidate.model : 'openai/gpt-4',
+        created_at:
+          typeof candidate.created_at === 'string' ? candidate.created_at : '2024-01-01',
+      } satisfies MockAgent;
+    })
+    .filter((agent): agent is MockAgent => agent !== null);
+};
+
+export const mockData: MockData = {
+  agents: normalizeAgents(parsed.agents),
+  secretaryMinutes:
+    typeof parsed.secretaryMinutes === 'string'
+      ? parsed.secretaryMinutes
+      : 'Meeting Minutes\n- Agenda review\n- Decisions recorded',
+  agentResponse:
+    typeof parsed.agentResponse === 'string'
+      ? parsed.agentResponse
+      : 'AI advancements look promising with collaborative intelligence.',
+};
+
+export const cloneAgents = (agents: MockAgent[]): MockAgent[] =>
+  agents.map((agent) => ({ ...agent }));

--- a/swarms-web/tests/e2e/mockedLetta.ts
+++ b/swarms-web/tests/e2e/mockedLetta.ts
@@ -1,0 +1,361 @@
+import { expect, Page } from '@playwright/test';
+
+import { cloneAgents, mockData, MockAgent } from './mockData.js';
+
+const STORAGE_KEY = '__PW_MOCK_LETTA_STATE__';
+
+const cloneState = (agents: MockAgent[], secretaryMinutes: string, agentResponse: string) => ({
+  agents: cloneAgents(agents),
+  secretaryMinutes,
+  agentResponse,
+});
+
+export class MockedLettaController {
+  private currentAgents: MockAgent[];
+  private secretaryMinutes: string;
+  private agentResponse: string;
+  private routesRegistered = false;
+
+  constructor(private readonly page: Page) {
+    this.currentAgents = cloneAgents(mockData.agents);
+    this.secretaryMinutes = mockData.secretaryMinutes;
+    this.agentResponse = mockData.agentResponse;
+  }
+
+  async init(): Promise<void> {
+    await this.syncStateWithPage();
+    await this.registerTestFlag();
+    await this.registerSocketStub();
+    await this.registerRoutes();
+  }
+
+  async reset(): Promise<void> {
+    this.currentAgents = cloneAgents(mockData.agents);
+    this.secretaryMinutes = mockData.secretaryMinutes;
+    this.agentResponse = mockData.agentResponse;
+    await this.syncStateWithPage();
+  }
+
+  async setAgents(agents: MockAgent[]): Promise<void> {
+    this.currentAgents = cloneAgents(agents);
+    await this.syncStateWithPage();
+  }
+
+  async setSecretaryMinutes(minutes: string): Promise<void> {
+    this.secretaryMinutes = minutes;
+    await this.syncStateWithPage();
+  }
+
+  async setAgentResponse(response: string): Promise<void> {
+    this.agentResponse = response;
+    await this.syncStateWithPage();
+  }
+
+  getAgents(): MockAgent[] {
+    return cloneAgents(this.currentAgents);
+  }
+
+  async startConversation(topic = 'Exploring AI collaboration'): Promise<void> {
+    await this.page.goto('/setup');
+
+    const agentCards = this.page.locator('.agent-card');
+    await expect(agentCards.first()).toBeVisible();
+
+    await agentCards.nth(0).locator('input.agent-checkbox').check();
+    await agentCards.nth(1).locator('input.agent-checkbox').check();
+
+    await this.page.locator('.mode-card').first().click();
+    await this.page.locator('#topic').fill(topic);
+
+    await this.page.locator('#start-chat-btn').click();
+
+    await this.page.waitForResponse('**/api/start_session');
+    await expect(this.page.locator('#chat-input')).toBeVisible();
+  }
+
+  async dispose(): Promise<void> {
+    if (this.routesRegistered) {
+      await this.page.unroute('**/socket.io.min.js*');
+      await this.page.unroute('**/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js*');
+      await this.page.unroute('**/api/agents');
+      this.routesRegistered = false;
+    }
+  }
+
+  private async syncStateWithPage(): Promise<void> {
+    const state = cloneState(this.currentAgents, this.secretaryMinutes, this.agentResponse);
+
+    await this.page.addInitScript(
+      ({ storageKey, value }) => {
+        try {
+          sessionStorage.setItem(storageKey, JSON.stringify(value));
+        } catch (error) {
+          console.warn('Failed to persist Playwright mock state', error);
+        }
+      },
+      { storageKey: STORAGE_KEY, value: state }
+    );
+
+    if (this.page.url() !== 'about:blank') {
+      await this.page.evaluate(
+        ({ storageKey, value }) => {
+          sessionStorage.setItem(storageKey, JSON.stringify(value));
+          const win = window as typeof window & { __PLAYWRIGHT_RESET_SOCKET?: () => void };
+          if (typeof win.__PLAYWRIGHT_RESET_SOCKET === 'function') {
+            win.__PLAYWRIGHT_RESET_SOCKET();
+          }
+        },
+        { storageKey: STORAGE_KEY, value: state }
+      );
+    }
+  }
+
+  private async registerTestFlag(): Promise<void> {
+    await this.page.addInitScript(() => {
+      (window as unknown as { __PLAYWRIGHT_TEST?: string }).__PLAYWRIGHT_TEST = '1';
+      try {
+        sessionStorage.setItem('sessionId', 'session-test');
+      } catch (error) {
+        // Ignore storage errors (e.g., disabled cookies)
+      }
+    });
+  }
+
+  private async registerSocketStub(): Promise<void> {
+    await this.page.addInitScript(
+      ({ storageKey }) => {
+        const getState = () => {
+          const defaults = {
+            agents: [],
+            secretaryMinutes: 'Meeting Minutes\n- Agenda review\n- Decisions recorded',
+            agentResponse: 'AI advancements look promising with collaborative intelligence.',
+          } as const;
+
+          try {
+            const raw = sessionStorage.getItem(storageKey);
+            if (!raw) {
+              return { ...defaults };
+            }
+            const parsed = JSON.parse(raw);
+            const agents = Array.isArray(parsed.agents) ? parsed.agents : [];
+            return {
+              agents,
+              secretaryMinutes:
+                typeof parsed.secretaryMinutes === 'string'
+                  ? parsed.secretaryMinutes
+                  : defaults.secretaryMinutes,
+              agentResponse:
+                typeof parsed.agentResponse === 'string'
+                  ? parsed.agentResponse
+                  : defaults.agentResponse,
+            };
+          } catch (error) {
+            console.error('Failed to parse Playwright mock state', error);
+            return { ...defaults };
+          }
+        };
+
+        class BootstrapToastStub {
+          element: HTMLElement;
+
+          constructor(element: HTMLElement) {
+            this.element = element;
+            setTimeout(() => {
+              const shownEvent = new CustomEvent('shown.bs.toast');
+              this.element.dispatchEvent(shownEvent);
+            }, 0);
+          }
+
+          show() {
+            setTimeout(() => {
+              const hiddenEvent = new CustomEvent('hidden.bs.toast');
+              this.element.dispatchEvent(hiddenEvent);
+            }, 1500);
+          }
+        }
+
+        const ensureBootstrap = () => {
+          const win = window as typeof window & { bootstrap?: { Toast: typeof BootstrapToastStub } };
+          if (!win.bootstrap) {
+            win.bootstrap = { Toast: BootstrapToastStub };
+          }
+        };
+
+        let socketInstance: {
+          on: (event: string, callback: (payload?: unknown) => void) => unknown;
+          off: (event?: string) => unknown;
+          emit: (event: string, payload?: Record<string, unknown>) => unknown;
+          disconnect: () => void;
+        } | null = null;
+
+        const createSocketFactory = () => {
+          if (socketInstance) {
+            return socketInstance;
+          }
+
+          const listeners = new Map<string, ((payload?: unknown) => void)[]>();
+
+          const ensureListeners = (event: string) => {
+            if (!listeners.has(event)) {
+              listeners.set(event, []);
+            }
+            return listeners.get(event)!;
+          };
+
+          const emitEvent = (event: string, payload?: unknown) => {
+            const handlers = listeners.get(event);
+            if (!handlers) {
+              return;
+            }
+            handlers.forEach((handler) => {
+              try {
+                handler(payload);
+              } catch (error) {
+                console.error('Mock socket handler error', error);
+              }
+            });
+          };
+
+          const socket = {
+            on(event: string, callback: (payload?: unknown) => void) {
+              ensureListeners(event).push(callback);
+              if (event === 'connect') {
+                setTimeout(() => callback(undefined), 0);
+              }
+              return socket;
+            },
+            off(event?: string) {
+              if (typeof event === 'string') {
+                listeners.delete(event);
+              } else {
+                listeners.clear();
+              }
+              return socket;
+            },
+            emit(event: string, payload?: Record<string, unknown>) {
+              const state = getState();
+
+              if (event === 'join_session' && payload?.session_id) {
+                setTimeout(() => emitEvent('joined', { session_id: payload.session_id }), 0);
+              }
+
+              if (event === 'start_chat' && payload?.topic) {
+                setTimeout(() => {
+                  emitEvent('chat_started', {
+                    topic: payload.topic,
+                    mode: 'hybrid',
+                    agents: state.agents.map((agent: { id: string; name: string }) => ({
+                      name: agent.name,
+                      id: agent.id,
+                    })),
+                    secretary_enabled: true,
+                  });
+                }, 50);
+              }
+
+              if (event === 'user_message' && typeof payload?.message === 'string') {
+                const message = String(payload.message);
+                const timestamp = new Date().toISOString();
+
+                setTimeout(() => {
+                  emitEvent('user_message', {
+                    speaker: 'You',
+                    message,
+                    timestamp,
+                  });
+                }, 0);
+
+                const trimmed = message.trim();
+
+                if (trimmed.startsWith('/')) {
+                  if (trimmed === '/minutes') {
+                    setTimeout(() => {
+                      const minutesContainer = document.getElementById('secretary-minutes');
+                      if (minutesContainer) {
+                        minutesContainer.style.display = 'block';
+                      }
+                      emitEvent('secretary_activity', {
+                        activity: 'generating',
+                        message: '📝 Generating meeting minutes...',
+                      });
+                      emitEvent('secretary_minutes', {
+                        minutes: state.secretaryMinutes,
+                      });
+                      emitEvent('secretary_activity', {
+                        activity: 'completed',
+                        message: '✅ Meeting minutes generated!',
+                      });
+                    }, 120);
+                  }
+                } else {
+                  setTimeout(() => {
+                    const fallbackSpeaker =
+                      state.agents[0]?.name || 'Agent';
+                    const fallbackMessage =
+                      state.agentResponse ||
+                      'AI advancements look promising with collaborative intelligence.';
+                    emitEvent('agent_message', {
+                      speaker: fallbackSpeaker,
+                      message: fallbackMessage,
+                      timestamp: new Date().toISOString(),
+                      phase: 'response',
+                    });
+                  }, 150);
+                }
+              }
+
+              return socket;
+            },
+            disconnect() {
+              listeners.clear();
+              socketInstance = null;
+            },
+          };
+
+          socketInstance = socket;
+          return socketInstance;
+        };
+
+        ensureBootstrap();
+
+        const win = window as typeof window & {
+          __playwrightCreateSocketIO?: () => unknown;
+          io?: () => unknown;
+          __PLAYWRIGHT_RESET_SOCKET?: () => void;
+        };
+
+        win.__playwrightCreateSocketIO = () => createSocketFactory();
+        win.io = () => createSocketFactory();
+        win.__PLAYWRIGHT_RESET_SOCKET = () => {
+          socketInstance = null;
+        };
+      },
+      { storageKey: STORAGE_KEY }
+    );
+  }
+
+  private async registerRoutes(): Promise<void> {
+    await this.page.route('**/socket.io.min.js*', async (route) => {
+      await route.fulfill({
+        contentType: 'application/javascript',
+        body: 'window.io = window.io || (window.__playwrightCreateSocketIO && window.__playwrightCreateSocketIO());',
+      });
+    });
+
+    await this.page.route('**/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js*', async (route) => {
+      await route.fulfill({
+        contentType: 'application/javascript',
+        body: 'window.bootstrap = window.bootstrap || { Toast: function ToastStub(){ this.show = function(){}; } };',
+      });
+    });
+
+    await this.page.route('**/api/agents', async (route) => {
+      await route.fulfill({
+        contentType: 'application/json',
+        body: JSON.stringify({ agents: this.currentAgents }),
+      });
+    });
+
+    this.routesRegistered = true;
+  }
+}


### PR DESCRIPTION
## Summary
- add a Playwright fixture module and hook it into `/api/agents` so the server returns deterministic agent data in test mode
- add shared mock data plus TypeScript fixtures for mocked Letta/socket behaviour and update the conversation spec to consume them

## Testing
- pytest swarms-web/tests

------
https://chatgpt.com/codex/tasks/task_b_68d311e5b84c8332ab68d8a7cc0fe05c