### PR TITLE
Improve agent score visibility and toast styling

### DIFF
--- a/swarms-web/static/js/main.js
+++ b/swarms-web/static/js/main.js
@@ -542,7 +542,9 @@ class SwarmsApp {
         // Update scores in sidebar if available
         const scoresContainer = document.getElementById('agent-scores');
         if (scoresContainer) {
-            scoresContainer.innerHTML = scores.map(score => `
+            const normalizedScores = Array.isArray(scores) ? scores : [];
+
+            scoresContainer.innerHTML = normalizedScores.map(score => `
                 <div class="agent-score-item">
                     <span class="agent-name">${score.name}</span>
                     <div class="score-badges">
@@ -551,6 +553,22 @@ class SwarmsApp {
                     </div>
                 </div>
             `).join('');
+
+            const scoresWrapper = document.getElementById('agent-scores-container');
+            if (scoresWrapper) {
+                if (normalizedScores.length > 0) {
+                    scoresWrapper.hidden = false;
+                    scoresWrapper.removeAttribute('hidden');
+                    scoresWrapper.classList.remove('hidden-by-default');
+                    scoresWrapper.style.removeProperty('display');
+                } else {
+                    scoresWrapper.hidden = true;
+                    scoresWrapper.setAttribute('hidden', 'true');
+                    scoresWrapper.classList.add('hidden-by-default');
+                    scoresWrapper.style.removeProperty('display');
+                    scoresContainer.innerHTML = '';
+                }
+            }
         }
     }
 
@@ -712,10 +730,14 @@ class SwarmsApp {
 
         // Initialize and show toast
         const bsToast = new bootstrap.Toast(toast);
+        toast.classList.add('show', 'showing');
+        requestAnimationFrame(() => toast.classList.remove('showing'));
+        toast.style.removeProperty('display');
         bsToast.show();
 
         // Remove toast element after it's hidden
         toast.addEventListener('hidden.bs.toast', () => {
+            toast.classList.remove('show');
             toast.remove();
         });
     }

--- a/swarms-web/templates/chat.html
+++ b/swarms-web/templates/chat.html
@@ -62,7 +62,7 @@
                 </div>
 
                 <!-- Agent Scores Display -->
-                <div id="agent-scores-container" class="agent-scores" style="display: none;">
+                <div id="agent-scores-container" class="agent-scores hidden-by-default" hidden>
                     <h6 class="mb-2">
                         <i class="bi bi-speedometer2"></i> Agent Motivation Scores
                     </h6>
@@ -826,18 +826,37 @@ class SimpleChat {
             assessmentIndicator.remove();
         }
 
-        // Update scores in sidebar
         const scoresContainer = document.getElementById('agent-scores');
-        if (scoresContainer) {
-            scoresContainer.innerHTML = scores.map(score => `
-                <div class="agent-score-item">
-                    <span class="agent-name">${score.name}</span>
-                    <div class="score-badges">
-                        <span class="score-badge">M: ${score.motivation_score}</span>
-                        <span class="score-badge">P: ${score.priority_score}</span>
-                    </div>
+        if (!scoresContainer) {
+            return;
+        }
+
+        const normalizedScores = Array.isArray(scores) ? scores : [];
+
+        scoresContainer.innerHTML = normalizedScores.map(score => `
+            <div class="agent-score-item">
+                <span class="agent-name">${score.name}</span>
+                <div class="score-badges">
+                    <span class="score-badge">M: ${score.motivation_score}</span>
+                    <span class="score-badge">P: ${score.priority_score}</span>
                 </div>
-            `).join('');
+            </div>
+        `).join('');
+
+        const scoresWrapper = document.getElementById('agent-scores-container');
+        if (scoresWrapper) {
+            if (normalizedScores.length > 0) {
+                scoresWrapper.hidden = false;
+                scoresWrapper.removeAttribute('hidden');
+                scoresWrapper.classList.remove('hidden-by-default');
+                scoresWrapper.style.removeProperty('display');
+            } else {
+                scoresWrapper.hidden = true;
+                scoresWrapper.setAttribute('hidden', 'true');
+                scoresWrapper.classList.add('hidden-by-default');
+                scoresWrapper.style.removeProperty('display');
+                scoresContainer.innerHTML = '';
+            }
         }
     }
 
@@ -1113,18 +1132,12 @@ class SimpleChat {
     }
 
     showToast(message, type = 'info') {
-        console.log('Toast:', message, type);
-
         // Create toast container if it doesn't exist
         let toastContainer = document.getElementById('toast-container');
         if (!toastContainer) {
             toastContainer = document.createElement('div');
             toastContainer.id = 'toast-container';
             toastContainer.className = 'toast-container';
-            toastContainer.style.position = 'fixed';
-            toastContainer.style.top = '80px';
-            toastContainer.style.right = '1rem';
-            toastContainer.style.zIndex = '1050';
             document.body.appendChild(toastContainer);
         }
 
@@ -1136,7 +1149,6 @@ class SimpleChat {
         };
         const bgColor = colorMap[type] || 'primary';
 
-        // Create toast
         const toast = document.createElement('div');
         toast.className = `toast align-items-center text-white bg-${bgColor} border-0`;
         toast.setAttribute('role', 'alert');
@@ -1153,12 +1165,18 @@ class SimpleChat {
 
         toastContainer.appendChild(toast);
 
-        // Initialize and show toast
         const bsToast = new bootstrap.Toast(toast);
+        toast.classList.add('show', 'showing');
+        if (typeof requestAnimationFrame === 'function') {
+            requestAnimationFrame(() => toast.classList.remove('showing'));
+        } else {
+            setTimeout(() => toast.classList.remove('showing'), 0);
+        }
+        toast.style.removeProperty('display');
         bsToast.show();
 
-        // Remove toast element after it's hidden
         toast.addEventListener('hidden.bs.toast', () => {
+            toast.classList.remove('show');
             toast.remove();
         });
     }

--- a/swarms-web/tests/e2e/chat_indicators.spec.ts
+++ b/swarms-web/tests/e2e/chat_indicators.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from './fixtures.js';
+
+test.describe('Chat indicator coverage', () => {
+  test('shows thinking indicators until an agent responds', async ({ startConversation, emitSocketEvent, page }) => {
+    const topic = 'Thinking indicator coverage';
+    await startConversation(topic);
+
+    await emitSocketEvent('agent_thinking', {
+      agent: 'Alex Johnson',
+      phase: 'analysis',
+      progress: '2/3',
+    });
+
+    const indicator = page.locator('.thinking-indicator');
+    await expect(indicator).toBeVisible();
+    await expect(indicator).toContainText('Alex Johnson is thinking');
+    await expect(indicator).toContainText('analysis');
+    await expect(indicator).toContainText('2/3');
+
+    await emitSocketEvent('agent_message', {
+      speaker: 'Alex Johnson',
+      message: 'Here is an analysis insight from Alex.',
+      timestamp: new Date().toISOString(),
+      phase: 'analysis',
+    });
+
+    await expect(indicator).not.toBeVisible();
+    await expect(page.locator('#chat-messages .message.agent').last()).toContainText('analysis insight');
+  });
+
+  test('renders assessment progress and motivation scores', async ({ startConversation, emitSocketEvent, page }) => {
+    await startConversation('Scoreboard coverage');
+
+    await emitSocketEvent('assessing_agents', {});
+    const progressIndicator = page.locator('#assessment-indicator');
+    await expect(progressIndicator).toBeVisible();
+    await expect(progressIndicator).toContainText('Assessing agent motivations');
+
+    await emitSocketEvent('agent_scores', {
+      scores: [
+        { name: 'Alex Johnson', motivation_score: '0.82', priority_score: '0.67' },
+        { name: 'Jordan Smith', motivation_score: '0.74', priority_score: '0.72' },
+      ],
+    });
+
+    const scoresWrapper = page.locator('#agent-scores-container');
+    await expect(progressIndicator).not.toBeVisible();
+    await expect(scoresWrapper).toBeVisible();
+    await expect(scoresWrapper).not.toHaveAttribute('hidden');
+    await expect(scoresWrapper).toContainText('Alex Johnson');
+    await expect(scoresWrapper).toContainText('M: 0.82');
+    await expect(scoresWrapper).toContainText('P: 0.67');
+    await expect(scoresWrapper).toContainText('Jordan Smith');
+
+    await emitSocketEvent('agent_scores', { scores: [] });
+    await expect(scoresWrapper).toBeHidden();
+    await expect(scoresWrapper).toHaveAttribute('hidden', 'true');
+  });
+
+  test('updates the phase indicator and toast styling', async ({ startConversation, emitSocketEvent, page }) => {
+    const topic = 'Phase coverage topic';
+
+    await startConversation(topic);
+
+    await emitSocketEvent('chat_started', {
+      topic,
+      mode: 'hybrid',
+      agents: [
+        { id: 'agent-1', name: 'Alex Johnson' },
+        { id: 'agent-2', name: 'Jordan Smith' },
+      ],
+      secretary_enabled: true,
+    });
+
+    const chatToast = page
+      .locator('#toast-container .toast')
+      .filter({ hasText: `Chat started: ${topic}` })
+      .first();
+    await expect(chatToast).toBeVisible({ timeout: 10000 });
+    await expect(chatToast).toHaveClass(/bg-success/);
+
+    await emitSocketEvent('phase_change', { phase: 'response_round' });
+    await expect(page.locator('#phase-indicator')).toHaveText(/Response Round/);
+
+    await page.evaluate(() => {
+      const win = window as unknown as {
+        swarmsApp: { showToast: (message: string, type?: string) => void };
+      };
+      win.swarmsApp.showToast('Heads up warning', 'warning');
+      win.swarmsApp.showToast('All clear success', 'success');
+    });
+
+    const warningToast = page
+      .locator('#toast-container .toast')
+      .filter({ hasText: 'Heads up warning' })
+      .first();
+    const successToast = page
+      .locator('#toast-container .toast')
+      .filter({ hasText: 'All clear success' })
+      .first();
+
+    await expect(warningToast).toBeVisible();
+    await expect(warningToast).toHaveClass(/bg-warning/);
+    await expect(successToast).toBeVisible();
+    await expect(successToast).toHaveClass(/bg-success/);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the agent score widget is toggled from JavaScript instead of relying on inline display attributes and apply the same behaviour to the fallback SimpleChat implementation
- adjust toast rendering to force Bootstrap toasts to render with the expected `.show` state in both SwarmsApp and SimpleChat
- add a dedicated Playwright suite that exercises thinking indicators, score visibility, and toast colour assertions

## Testing
- `npx playwright test --workers=1`


------
https://chatgpt.com/codex/tasks/task_b_68d55df560808332baab4683cc9e1097

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an agent scores container that shows/hides based on available scores and renders score items consistently.
- Bug Fixes
  - Improved handling of agent scores when data is missing or malformed; clears UI when no scores exist.
  - Refined toast animations and cleanup for smoother show/hide behavior and proper removal after hiding.
- Tests
  - Added end-to-end tests covering thinking indicators, assessment progress, agent scores visibility, phase indicator updates, and toast styling/behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->