### PR TITLE
Add Playwright coverage for session chat navigation

### DIFF
--- a/swarms-web/templates/sessions.html
+++ b/swarms-web/templates/sessions.html
@@ -473,14 +473,31 @@ class SessionManager {
                 throw new Error(result.error || 'Failed to create session');
             }
 
+            const sessionId = result.id || result.session_id;
+            if (!sessionId) {
+                throw new Error('Server did not return a session ID');
+            }
+
             this.showToast('Session created successfully!', 'success');
+
+            try {
+                sessionStorage.setItem('sessionId', sessionId);
+                if (title) {
+                    sessionStorage.setItem('topic', title);
+                } else {
+                    sessionStorage.removeItem('topic');
+                }
+            } catch (storageError) {
+                console.warn('Unable to persist session context', storageError);
+            }
 
             // Clear form
             if (titleInput) titleInput.value = '';
             if (tagsInput) tagsInput.value = '';
 
-            // Reload sessions list
-            this.loadSessions();
+            setTimeout(() => {
+                window.location.href = `/chat?sessionId=${encodeURIComponent(sessionId)}`;
+            }, 300);
 
         } catch (error) {
             console.error('Error creating session:', error);
@@ -508,12 +525,23 @@ class SessionManager {
             }
 
             if (result.ok) {
+                const resumedSessionId = result.id || result.session_id || sessionId;
+                if (!resumedSessionId) {
+                    throw new Error('Server did not return a session ID');
+                }
+
                 this.showToast('Session resumed successfully!', 'success');
 
-                // Redirect to chat page after a short delay
+                try {
+                    sessionStorage.setItem('sessionId', resumedSessionId);
+                    sessionStorage.removeItem('topic');
+                } catch (storageError) {
+                    console.warn('Unable to persist session context', storageError);
+                }
+
                 setTimeout(() => {
-                    window.location.href = '/chat';
-                }, 1000);
+                    window.location.href = `/chat?sessionId=${encodeURIComponent(resumedSessionId)}`;
+                }, 300);
             } else {
                 throw new Error(result.error || 'Failed to resume session');
             }

--- a/swarms-web/tests/e2e/sessions.spec.ts
+++ b/swarms-web/tests/e2e/sessions.spec.ts
@@ -73,11 +73,11 @@ test.describe('Session management lifecycle', () => {
   const createRequests: Record<string, unknown>[] = [];
   test.beforeEach(async ({ page }, testInfo) => {
     const uniqueSuffix = [
-      testInfo.workerIndex ?? 0,
-      testInfo.parallelIndex ?? 0,
-      testInfo.repeatEachIndex ?? 0,
-      testInfo.retry ?? 0,
+      testInfo.workerIndex,
+      testInfo.repeatEachIndex,
+      testInfo.retry,
       Date.now().toString(36),
+      Math.random().toString(36).slice(2, 8),
     ].join('-');
 
     sessionPrefix = `test-sess-A-${uniqueSuffix}`;


### PR DESCRIPTION
## Summary
- update the sessions dashboard to persist the returned session id and redirect to the chat view after creating or resuming a session
- refresh the Playwright session management spec with per-test fixtures and add assertions for chat navigation flows

## Testing
- npx playwright test tests/e2e/sessions.spec.ts *(fails: Playwright browsers not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d57adea4cc8332afefb8764a3a4e77

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - More reliable session creation and resumption with consistent session ID handling.
- Bug Fixes
  - URL now updates with the correct session ID after creating or resuming a session.
  - Improved error handling when a server response lacks a session ID.
  - Session title is now stored or cleared consistently based on availability.
- Tests
  - E2E tests updated to use unique, per-run session ID prefixes, reducing collisions and flakiness.
  - Assertions and route handlers adjusted to align with the new dynamic session ID format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->