### PR TITLE
Add conversation flow Playwright coverage

### DIFF
--- a/swarms-web/tests/e2e/conversation_flow.spec.ts
+++ b/swarms-web/tests/e2e/conversation_flow.spec.ts
@@ -29,11 +29,20 @@ test.describe('Prompt B conversation flow', () => {
       .first();
     await expect(userBubble).toBeVisible();
 
+    await chatInput.fill(userMessage);
+    await chatInput.press('Enter');
+
     await emitSocketEvent('agent_thinking', {
       agent: THINKING_AGENT,
       phase: 'response',
       progress: '1/1',
     });
+
+    const userBubble = page
+      .locator('#chat-messages .message.user')
+      .filter({ hasText: userMessage })
+      .first();
+    await expect(userBubble).toBeVisible();
 
     const thinkingIndicator = page
       .locator('.thinking-indicator')

--- a/swarms-web/tests/e2e/conversation_flow.spec.ts
+++ b/swarms-web/tests/e2e/conversation_flow.spec.ts
@@ -1,0 +1,79 @@
+import { expect, test } from './fixtures.js';
+
+const THINKING_AGENT = 'Alex Johnson';
+
+function uniqueTopic(): string {
+  return `Prompt B conversation flow ${Date.now()}`;
+}
+
+test.describe('Prompt B conversation flow', () => {
+  test('renders ordered chat bubbles and clears interim indicators', async ({
+    startConversation,
+    emitSocketEvent,
+    page,
+    setAgentResponse,
+  }) => {
+    const userMessage = 'How is the swarm prioritizing current objectives?';
+    const agentReply = 'Priorities are rotated based on momentum and urgency in this mock reply.';
+
+    await setAgentResponse(agentReply);
+    await startConversation(uniqueTopic());
+
+    const chatInput = page.locator('#chat-input');
+    await chatInput.fill(userMessage);
+    await chatInput.press('Enter');
+
+    const userBubble = page
+      .locator('#chat-messages .message.user')
+      .filter({ hasText: userMessage })
+      .first();
+    await expect(userBubble).toBeVisible();
+
+    await emitSocketEvent('agent_thinking', {
+      agent: THINKING_AGENT,
+      phase: 'response',
+      progress: '1/1',
+    });
+
+    const thinkingIndicator = page
+      .locator('.thinking-indicator')
+      .filter({ hasText: THINKING_AGENT })
+      .first();
+    await expect(thinkingIndicator).toBeVisible();
+
+    const agentBubble = page
+      .locator('#chat-messages .message.agent')
+      .filter({ hasText: agentReply })
+      .first();
+    await expect(agentBubble).toBeVisible();
+
+    await expect(thinkingIndicator).toBeHidden();
+
+    const ordering = await page.evaluate(
+      ({ userText, agentText }) => {
+        const nodes = Array.from(
+          document.querySelectorAll('#chat-messages .message')
+        );
+        const userIndex = nodes.findIndex(
+          (node) =>
+            node.classList.contains('user') &&
+            node.textContent?.includes(userText)
+        );
+        const agentIndex = nodes.findIndex(
+          (node) =>
+            node.classList.contains('agent') &&
+            node.textContent?.includes(agentText)
+        );
+        return { userIndex, agentIndex };
+      },
+      { userText: userMessage, agentText: agentReply }
+    );
+
+    expect(ordering.userIndex).toBeGreaterThan(-1);
+    expect(ordering.agentIndex).toBeGreaterThan(-1);
+    expect(ordering.userIndex).toBeLessThan(ordering.agentIndex);
+
+    await expect(page.locator('#secretary-minutes')).toBeHidden();
+    await expect(page.locator('#exportModal')).toHaveAttribute('aria-hidden', 'true');
+  });
+});

--- a/swarms-web/tests/e2e/mockedLetta.ts
+++ b/swarms-web/tests/e2e/mockedLetta.ts
@@ -181,19 +181,23 @@ export class MockedLettaController {
           }
         };
 
-        let socketInstance: {
-          on: (event: string, callback: (payload?: unknown) => void) => unknown;
-          off: (event?: string) => unknown;
-          emit: (event: string, payload?: Record<string, unknown>) => unknown;
+        type Listener = (payload?: unknown) => void;
+        type SocketStub = {
+          on: (event: string, callback: Listener) => SocketStub;
+          off: (event?: string) => SocketStub;
+          emit: (event: string, payload?: Record<string, unknown>) => SocketStub;
           disconnect: () => void;
-        } | null = null;
+          __playwrightEmitDirect?: (event: string, payload?: unknown) => void;
+        };
+
+        let socketInstance: SocketStub | null = null;
 
         const createSocketFactory = () => {
           if (socketInstance) {
             return socketInstance;
           }
 
-          const listeners = new Map<string, ((payload?: unknown) => void)[]>();
+          const listeners = new Map<string, Listener[]>();
 
           const ensureListeners = (event: string) => {
             if (!listeners.has(event)) {
@@ -216,8 +220,8 @@ export class MockedLettaController {
             });
           };
 
-          const socket = {
-            on(event: string, callback: (payload?: unknown) => void) {
+          const socket: SocketStub = {
+            on(event: string, callback: Listener) {
               ensureListeners(event).push(callback);
               if (event === 'connect') {
                 setTimeout(() => callback(undefined), 0);
@@ -312,6 +316,8 @@ export class MockedLettaController {
             },
           };
 
+          socket.__playwrightEmitDirect = emitEvent;
+
           socketInstance = socket;
           return socketInstance;
         };
@@ -319,15 +325,23 @@ export class MockedLettaController {
         ensureBootstrap();
 
         const win = window as typeof window & {
-          __playwrightCreateSocketIO?: () => unknown;
+          __playwrightCreateSocketIO?: () => SocketStub;
           io?: () => unknown;
           __PLAYWRIGHT_RESET_SOCKET?: () => void;
+          __playwrightEmitSocketEvent?: (event: string, payload?: unknown) => void;
         };
 
         win.__playwrightCreateSocketIO = () => createSocketFactory();
         win.io = () => createSocketFactory();
         win.__PLAYWRIGHT_RESET_SOCKET = () => {
           socketInstance = null;
+        };
+        win.__playwrightEmitSocketEvent = (event: string, payload?: unknown) => {
+          const socket = createSocketFactory();
+          const emitter = socket.__playwrightEmitDirect;
+          if (typeof emitter === 'function') {
+            emitter(event, payload);
+          }
         };
       },
       { storageKey: STORAGE_KEY }


### PR DESCRIPTION
## Summary
- extend the Playwright fixtures with helpers to emit socket events and override agent replies
- expose a direct socket event emitter from the mocked Letta controller to support the new helper
- add an end-to-end conversation flow test that checks message ordering, loading indicators, and absence of secretary/export side effects

## Testing
- `cd swarms-web && npx playwright test tests/e2e/conversation_flow.spec.ts`


------
https://chatgpt.com/codex/tasks/task_b_68d57b151d388332a0b114da9a46f02b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for the chat conversation flow, validating message ordering, interim “thinking” state, and visibility of related UI elements.
  * Extended test utilities to simulate socket events and configure agent replies, enabling realistic chat scenario testing.
  * Refined mock socket behavior to allow direct event triggering in tests, enhancing reliability of interaction checks.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->