### PR TITLE
Add Playwright coverage for secretary slash commands

### DIFF
--- a/swarms-web/tests/e2e/mockedLetta.ts
+++ b/swarms-web/tests/e2e/mockedLetta.ts
@@ -194,6 +194,7 @@ export class MockedLettaController {
           }
 
           const listeners = new Map<string, ((payload?: unknown) => void)[]>();
+          const commandTimers = new Map<string, number[]>();
 
           const ensureListeners = (event: string) => {
             if (!listeners.has(event)) {
@@ -214,6 +215,64 @@ export class MockedLettaController {
                 console.error('Mock socket handler error', error);
               }
             });
+          };
+
+          const clearCommandTimers = (commandKey?: string) => {
+            const keys = typeof commandKey === 'string' ? [commandKey] : Array.from(commandTimers.keys());
+            keys.forEach((key) => {
+              const timers = commandTimers.get(key);
+              if (timers) {
+                timers.forEach((timerId) => {
+                  try {
+                    clearTimeout(timerId);
+                  } catch (error) {
+                    console.warn('Failed to clear mock command timer', error);
+                  }
+                });
+                commandTimers.delete(key);
+              }
+            });
+          };
+
+          const scheduleCommandTasks = (
+            commandKey: string,
+            tasks: { delay: number; run: () => void }[]
+          ) => {
+            clearCommandTimers(commandKey);
+
+            if (!Array.isArray(tasks) || tasks.length === 0) {
+              return;
+            }
+
+            const activeTimers: number[] = [];
+
+            tasks.forEach((task) => {
+              const delay = typeof task.delay === 'number' ? task.delay : 0;
+              const timerId = window.setTimeout(() => {
+                try {
+                  task.run();
+                } finally {
+                  const timers = commandTimers.get(commandKey);
+                  if (timers) {
+                    const index = timers.indexOf(timerId);
+                    if (index >= 0) {
+                      timers.splice(index, 1);
+                    }
+                    if (timers.length === 0) {
+                      commandTimers.delete(commandKey);
+                    } else {
+                      commandTimers.set(commandKey, timers);
+                    }
+                  }
+                }
+              }, delay);
+
+              activeTimers.push(timerId);
+            });
+
+            if (activeTimers.length > 0) {
+              commandTimers.set(commandKey, activeTimers);
+            }
           };
 
           const socket = {
@@ -268,24 +327,153 @@ export class MockedLettaController {
                 const trimmed = message.trim();
 
                 if (trimmed.startsWith('/')) {
-                  if (trimmed === '/minutes') {
-                    setTimeout(() => {
-                      const minutesContainer = document.getElementById('secretary-minutes');
-                      if (minutesContainer) {
-                        minutesContainer.style.display = 'block';
-                      }
-                      emitEvent('secretary_activity', {
-                        activity: 'generating',
-                        message: '📝 Generating meeting minutes...',
-                      });
-                      emitEvent('secretary_minutes', {
-                        minutes: state.secretaryMinutes,
-                      });
-                      emitEvent('secretary_activity', {
-                        activity: 'completed',
-                        message: '✅ Meeting minutes generated!',
-                      });
-                    }, 120);
+                  const [rawCommand] = trimmed.split(/\s+/, 1);
+                  const commandKey = rawCommand.slice(1).toLowerCase();
+                  const schedule = (
+                    key: string,
+                    tasks: { delay: number; run: () => void }[]
+                  ) => scheduleCommandTasks(key, tasks);
+
+                  if (commandKey === 'minutes') {
+                    schedule(commandKey, [
+                      {
+                        delay: 60,
+                        run: () => {
+                          emitEvent('secretary_activity', {
+                            activity: 'generating',
+                            message: '📝 Generating meeting minutes...',
+                          });
+                        },
+                      },
+                      {
+                        delay: 140,
+                        run: () => {
+                          const minutesContainer = document.getElementById('secretary-minutes');
+                          if (minutesContainer) {
+                            minutesContainer.style.display = 'block';
+                          }
+                          emitEvent('secretary_minutes', {
+                            minutes: state.secretaryMinutes,
+                          });
+                        },
+                      },
+                      {
+                        delay: 220,
+                        run: () => {
+                          emitEvent('secretary_activity', {
+                            activity: 'completed',
+                            message: '✅ Meeting minutes generated!',
+                          });
+                        },
+                      },
+                    ]);
+                  } else if (commandKey === 'stats') {
+                    schedule(commandKey, [
+                      {
+                        delay: 70,
+                        run: () => {
+                          emitEvent('secretary_activity', {
+                            activity: 'generating',
+                            message: '📊 Gathering conversation statistics...',
+                          });
+                        },
+                      },
+                      {
+                        delay: 160,
+                        run: () => {
+                          const activeAgents = Array.isArray(state.agents)
+                            ? state.agents.length
+                            : 0;
+                          const respondingAgents = Math.min(activeAgents, 2);
+                          emitEvent('secretary_stats', {
+                            stats: {
+                              'Total Messages': 12,
+                              'Agents Responded': `${respondingAgents} / ${activeAgents || respondingAgents}`,
+                              'Action Items Logged': 3,
+                            },
+                          });
+                        },
+                      },
+                      {
+                        delay: 240,
+                        run: () => {
+                          emitEvent('secretary_activity', {
+                            activity: 'completed',
+                            message: '📈 Conversation stats are ready!',
+                          });
+                        },
+                      },
+                    ]);
+                  } else if (commandKey === 'memory-status') {
+                    schedule(commandKey, [
+                      {
+                        delay: 90,
+                        run: () => {
+                          const agentCount = Array.isArray(state.agents)
+                            ? state.agents.length
+                            : 0;
+                          emitEvent('secretary_status', {
+                            status: 'awareness',
+                            agent_name: 'Memory Monitor',
+                            mode: 'memory tracking',
+                            message: `Memory status summarized for ${agentCount || 0} agents.`,
+                          });
+                        },
+                      },
+                    ]);
+                  } else if (commandKey === 'memory-awareness') {
+                    schedule(commandKey, [
+                      {
+                        delay: 90,
+                        run: () => {
+                          emitEvent('secretary_status', {
+                            status: 'insight',
+                            agent_name: 'Memory Monitor',
+                            mode: 'awareness check',
+                            message: 'Agents notified about recent memory usage.',
+                          });
+                        },
+                      },
+                    ]);
+                  } else if (commandKey === 'help' || commandKey === 'commands') {
+                    schedule(commandKey, [
+                      {
+                        delay: 80,
+                        run: () => {
+                          emitEvent('system_message', {
+                            message: [
+                              '📝 Available Commands:',
+                              '',
+                              'Memory Awareness (Available Always):',
+                              '  /memory-status     - Show objective memory statistics for all agents',
+                              '  /memory-awareness  - Display neutral memory awareness information if criteria are met',
+                              '',
+                              'Secretary Commands (When Secretary Enabled):',
+                              '  /minutes           - Generate current meeting minutes',
+                              '  /stats             - Show conversation statistics',
+                              '',
+                              'Documentation: https://docs.letta.ai/commands',
+                              '  /help              - Show this help message',
+                            ].join('\n'),
+                            timestamp: new Date().toISOString(),
+                          });
+                        },
+                      },
+                    ]);
+                  } else {
+                    schedule('unknown', [
+                      {
+                        delay: 60,
+                        run: () => {
+                          emitEvent('secretary_status', {
+                            status: 'error',
+                            agent_name: 'Secretary',
+                            mode: 'command-center',
+                            message: 'Unknown command',
+                          });
+                        },
+                      },
+                    ]);
                   }
                 } else {
                   setTimeout(() => {
@@ -307,6 +495,7 @@ export class MockedLettaController {
               return socket;
             },
             disconnect() {
+              clearCommandTimers();
               listeners.clear();
               socketInstance = null;
             },
@@ -326,9 +515,18 @@ export class MockedLettaController {
 
         win.__playwrightCreateSocketIO = () => createSocketFactory();
         win.io = () => createSocketFactory();
-        win.__PLAYWRIGHT_RESET_SOCKET = () => {
-          socketInstance = null;
-        };
+          win.__PLAYWRIGHT_RESET_SOCKET = () => {
+            if (socketInstance && typeof socketInstance.disconnect === 'function') {
+              try {
+                socketInstance.disconnect();
+              } catch (error) {
+                console.warn('Failed to disconnect mock socket instance', error);
+              }
+            } else {
+              clearCommandTimers();
+            }
+            socketInstance = null;
+          };
       },
       { storageKey: STORAGE_KEY }
     );

--- a/swarms-web/tests/e2e/slash_commands.spec.ts
+++ b/swarms-web/tests/e2e/slash_commands.spec.ts
@@ -1,0 +1,92 @@
+import { expect, test } from './fixtures.js';
+
+const sendSlashCommand = async (page: import('@playwright/test').Page, command: string) => {
+  await page.locator('#chat-input').fill(command);
+  await page.locator('#send-button').click();
+};
+
+test.describe('Secretary slash commands', () => {
+  test('reveals meeting minutes when /minutes is submitted', async ({ startConversation, page }) => {
+    await startConversation('Minutes coverage scenario');
+
+    await sendSlashCommand(page, '/minutes');
+
+    const minutesPanel = page.locator('#secretary-minutes pre');
+    await expect(minutesPanel).toBeVisible();
+    await expect(minutesPanel).toContainText('Meeting Minutes');
+    await expect(page.locator('#secretary-content')).toContainText('Meeting minutes generated');
+  });
+
+  test('displays conversation statistics for /stats', async ({ startConversation, page }) => {
+    await startConversation('Stats coverage scenario');
+
+    await sendSlashCommand(page, '/stats');
+
+    const statsPanel = page.locator('#secretary-stats');
+    const statRows = statsPanel.locator('.d-flex.justify-content-between');
+
+    await expect(statRows).toHaveCount(3);
+    await expect(statRows.nth(0)).toContainText('Total Messages');
+    await expect(statRows.nth(1)).toContainText('Agents Responded');
+    await expect(statRows.nth(2)).toContainText('Action Items Logged');
+    await expect(page.locator('#secretary-content')).toContainText('Conversation stats are ready');
+  });
+
+  test('surfaces a toast describing memory usage for /memory-status', async ({ startConversation, page }) => {
+    await startConversation('Memory status scenario');
+
+    await sendSlashCommand(page, '/memory-status');
+
+    const toast = page.locator('#toast-container .toast').last();
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText('Memory status summarized for 3 agents.');
+  });
+
+  test('alerts agents about awareness checks for /memory-awareness', async ({ startConversation, page }) => {
+    await startConversation('Memory awareness scenario');
+
+    await sendSlashCommand(page, '/memory-awareness');
+
+    const toast = page.locator('#toast-container .toast').last();
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText('Agents notified about recent memory usage.');
+  });
+
+  test('shows help documentation and links for /help', async ({ startConversation, page }) => {
+    await startConversation('Help command scenario');
+
+    await sendSlashCommand(page, '/help');
+
+    const helpMessage = page
+      .locator('#chat-messages .message.system')
+      .filter({ hasText: 'Available Commands' })
+      .first();
+
+    await expect(helpMessage).toBeVisible();
+    await expect(helpMessage).toContainText('/memory-status');
+    await expect(helpMessage).toContainText('/stats');
+    const docsLink = helpMessage.locator('a[href="https://docs.letta.ai/commands"]');
+    await expect(docsLink).toHaveCount(1);
+  });
+
+  test('warns about unknown commands with a toast notification', async ({ startConversation, page }) => {
+    await startConversation('Unknown command scenario');
+
+    await sendSlashCommand(page, '/does-not-exist');
+
+    const toast = page.locator('#toast-container .toast').last();
+    await expect(toast).toBeVisible();
+    await expect(toast).toContainText('Unknown command');
+  });
+
+  test('does not duplicate results when /stats is issued repeatedly', async ({ startConversation, page }) => {
+    await startConversation('Repeated stats scenario');
+
+    await sendSlashCommand(page, '/stats');
+    await sendSlashCommand(page, '/stats');
+
+    const statRows = page.locator('#secretary-stats .d-flex.justify-content-between');
+    await expect(statRows).toHaveCount(3);
+    await expect(statRows.nth(1)).toContainText('Agents Responded');
+  });
+});


### PR DESCRIPTION
## Summary
- expand the mocked Socket.IO controller so slash commands emit stats, minutes, memory, help, and unknown-command events with debounced timers
- add a Playwright E2E suite that exercises /minutes, /stats, /memory-status, /memory-awareness, /help, and unknown commands, including repeat-command assertions

## Testing
- `npx playwright test tests/e2e/slash_commands.spec.ts` *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68d57b919a00833290b38c6969e0c58f