### PR TITLE
Add UI banner for trimmed chat messages

### DIFF
--- a/swarms-web/templates/chat.html
+++ b/swarms-web/templates/chat.html
@@ -78,6 +78,26 @@
                         <div class="d-flex flex-wrap gap-2" id="attachment-chips"></div>
                     </div>
 
+                    <div id="token-limit-banner" class="alert alert-warning d-flex align-items-start gap-3 py-2 px-3 mb-2" role="status" hidden>
+                        <div class="flex-grow-1">
+                            <div class="fw-semibold">
+                                <i class="bi bi-exclamation-triangle me-1"></i>
+                                Message trimmed to stay within token limits.
+                            </div>
+                            <div class="small text-muted" data-role="trim-summary">
+                                Sent <span data-role="trimmed-count">0</span> of <span data-role="original-count">0</span> characters.
+                            </div>
+                        </div>
+                        <div class="d-flex align-items-center gap-2 flex-shrink-0">
+                            <button type="button" id="show-trimmed-full" class="btn btn-sm btn-outline-dark" disabled>
+                                Show full message
+                            </button>
+                            <button type="button" id="dismiss-trimmed-banner" class="btn btn-sm btn-link text-decoration-none">
+                                Dismiss
+                            </button>
+                        </div>
+                    </div>
+
                     <div class="input-group">
                         <div class="input-group-prepend">
                             <button class="btn btn-outline-secondary" type="button" id="attach-button"
@@ -267,6 +287,29 @@
     </div>
 </div>
 
+<!-- Trimmed Message Modal -->
+<div class="modal fade" id="trimmedMessageModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">
+                    <i class="bi bi-file-text"></i> Full message content
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p class="small text-muted mb-3">
+                    Only the first <span id="trimmed-message-count">0</span> characters were sent to the agents to avoid token limits.
+                </p>
+                <pre id="trimmed-message-full" class="border rounded p-3 mb-0" style="white-space: pre-wrap;"></pre>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Toast container for notifications -->
 <div id="toast-container" class="toast-container"></div>
 {% endblock %}
@@ -274,6 +317,14 @@
 {% block extra_scripts %}
 <script>
 document.body.setAttribute('data-page', 'chat');
+
+const DEFAULT_CHAT_MESSAGE_CHAR_LIMIT = 24000;
+const parsedChatLimit = Number(document.body?.dataset?.maxChatChars ?? NaN);
+const CHAT_MESSAGE_CHAR_LIMIT =
+    Number.isFinite(parsedChatLimit) && parsedChatLimit > 0
+        ? Math.floor(parsedChatLimit)
+        : DEFAULT_CHAT_MESSAGE_CHAR_LIMIT;
+window.__CHAT_MESSAGE_LIMIT__ = CHAT_MESSAGE_CHAR_LIMIT;
 
 // Simple self-contained chat functionality
 class SimpleChat {
@@ -283,6 +334,9 @@ class SimpleChat {
         this.isConnected = false;
         this.agents = [];
         this.pendingAttachments = []; // Store uploaded attachments before sending
+        this.messageLimit = CHAT_MESSAGE_CHAR_LIMIT;
+        window.__CHAT_MESSAGE_LIMIT__ = this.messageLimit;
+        this.lastTrimmedMessage = null;
         this.exportLabels = {
             formal: 'Formal Minutes',
             casual: 'Casual Notes',
@@ -485,6 +539,22 @@ class SimpleChat {
             });
         }
 
+        const dismissTrimmedButton = document.getElementById('dismiss-trimmed-banner');
+        if (dismissTrimmedButton) {
+            dismissTrimmedButton.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.clearTrimmedWarning();
+            });
+        }
+
+        const showTrimmedButton = document.getElementById('show-trimmed-full');
+        if (showTrimmedButton) {
+            showTrimmedButton.addEventListener('click', (e) => {
+                e.preventDefault();
+                this.openTrimmedModal();
+            });
+        }
+
         // Setup secretary commands
         document.querySelectorAll('.secretary-command').forEach(button => {
             button.addEventListener('click', (e) => {
@@ -494,6 +564,8 @@ class SimpleChat {
                 this.sendMessage(command);
             });
         });
+
+        this.renderTrimmedBanner();
 
         // Show connection modal initially
         this.showConnectionModal();
@@ -603,17 +675,146 @@ class SimpleChat {
         document.getElementById('attachment-preview').style.display = 'none';
     }
 
+    applyMessageLimit(messageText) {
+        const limit = Number.isFinite(this.messageLimit) && this.messageLimit > 0
+            ? Math.floor(this.messageLimit)
+            : CHAT_MESSAGE_CHAR_LIMIT;
+
+        const normalized = typeof messageText === 'string' ? messageText : String(messageText ?? '');
+
+        if (!normalized) {
+            return { message: '', trimmed: false };
+        }
+
+        if (normalized.length <= limit) {
+            return { message: normalized, trimmed: false };
+        }
+
+        const trimmedMessage = normalized.slice(0, limit);
+        return { message: trimmedMessage, trimmed: true };
+    }
+
+    showTrimmedWarning(originalMessage, trimmedMessage) {
+        this.lastTrimmedMessage = {
+            original: originalMessage,
+            trimmed: trimmedMessage,
+            limit: this.messageLimit
+        };
+
+        this.renderTrimmedBanner();
+        this.showToast('Message trimmed to stay within token limits.', 'warning');
+    }
+
+    clearTrimmedWarning() {
+        if (!this.lastTrimmedMessage) {
+            this.renderTrimmedBanner();
+            return;
+        }
+
+        this.lastTrimmedMessage = null;
+        this.renderTrimmedBanner();
+    }
+
+    renderTrimmedBanner() {
+        const banner = document.getElementById('token-limit-banner');
+        const trimmedCount = banner ? banner.querySelector('[data-role="trimmed-count"]') : null;
+        const originalCount = banner ? banner.querySelector('[data-role="original-count"]') : null;
+        const summary = banner ? banner.querySelector('[data-role="trim-summary"]') : null;
+        const showButton = document.getElementById('show-trimmed-full');
+
+        if (!banner) {
+            return;
+        }
+
+        if (this.lastTrimmedMessage) {
+            const { original, trimmed } = this.lastTrimmedMessage;
+            if (trimmedCount) {
+                trimmedCount.textContent = this.formatCount(trimmed.length);
+            }
+            if (originalCount) {
+                originalCount.textContent = this.formatCount(original.length);
+            }
+            if (summary) {
+                summary.setAttribute('aria-live', 'polite');
+            }
+
+            banner.hidden = false;
+            banner.style.display = 'flex';
+            if (showButton) {
+                showButton.disabled = false;
+            }
+        } else {
+            banner.hidden = true;
+            banner.style.display = 'none';
+            if (trimmedCount) {
+                trimmedCount.textContent = '0';
+            }
+            if (originalCount) {
+                originalCount.textContent = '0';
+            }
+            if (summary) {
+                summary.removeAttribute('aria-live');
+            }
+            if (showButton) {
+                showButton.disabled = true;
+            }
+        }
+    }
+
+    openTrimmedModal() {
+        if (!this.lastTrimmedMessage) {
+            return;
+        }
+
+        const modalElement = document.getElementById('trimmedMessageModal');
+        const messageContainer = document.getElementById('trimmed-message-full');
+        const countElement = document.getElementById('trimmed-message-count');
+
+        if (messageContainer) {
+            messageContainer.textContent = this.lastTrimmedMessage.original;
+        }
+
+        if (countElement) {
+            countElement.textContent = this.formatCount(this.lastTrimmedMessage.trimmed.length);
+        }
+
+        if (!modalElement) {
+            return;
+        }
+
+        if (window.bootstrap?.Modal) {
+            const instance = window.bootstrap.Modal.getOrCreateInstance(modalElement, { backdrop: 'static' });
+            instance.show();
+        } else {
+            modalElement.classList.add('show');
+            modalElement.style.display = 'block';
+            modalElement.removeAttribute('aria-hidden');
+        }
+    }
+
+    formatCount(value) {
+        try {
+            return new Intl.NumberFormat().format(value);
+        } catch (error) {
+            return String(value);
+        }
+    }
+
     sendMessage(message = null) {
         const chatInput = document.getElementById('chat-input');
-        if (!chatInput && !message) return;
+        if (!chatInput && message === null) return;
 
-        const messageText = message || chatInput.value.trim();
-        if (!messageText && this.pendingAttachments.length === 0) return;
+        const rawValue = typeof message === 'string' ? message : (chatInput ? chatInput.value : '');
+        const normalizedMessage = typeof message === 'string' ? rawValue : rawValue.trim();
+
+        if (!normalizedMessage && this.pendingAttachments.length === 0) return;
+
+        const { message: limitedMessage, trimmed } = this.applyMessageLimit(normalizedMessage);
 
         // Prepare message data
         const messageData = {
             session_id: this.sessionId,
-            message: messageText || ""
+            message: limitedMessage || ''
         };
 
         // Include attachments if any
@@ -621,8 +822,14 @@ class SimpleChat {
             messageData.attachments = this.pendingAttachments;
         }
 
+        if (trimmed) {
+            this.showTrimmedWarning(normalizedMessage, limitedMessage);
+        } else {
+            this.clearTrimmedWarning();
+        }
+
         // Clear input if it was from the input field
-        if (!message && chatInput) {
+        if (message === null && chatInput) {
             chatInput.value = '';
             chatInput.style.height = 'auto';
         }
@@ -634,7 +841,7 @@ class SimpleChat {
                 this.sendMessageWithAttachments(messageData);
             } else {
                 // For text-only messages, use WebSocket
-                console.log('Sending text message:', messageText);
+                console.log('Sending text message:', limitedMessage);
                 this.socket.emit('user_message', messageData);
             }
         }

--- a/swarms-web/tests/e2e/token-limits.spec.ts
+++ b/swarms-web/tests/e2e/token-limits.spec.ts
@@ -1,0 +1,150 @@
+import { expect, Page } from '@playwright/test';
+
+import { test } from './fixtures.js';
+
+const getCharacterLimit = async (page: Page) => {
+  return page.evaluate(() => {
+    const globalLimit = (window as typeof window & { __CHAT_MESSAGE_LIMIT__?: number }).__CHAT_MESSAGE_LIMIT__;
+    if (typeof globalLimit === 'number' && Number.isFinite(globalLimit)) {
+      return globalLimit;
+    }
+    const simpleChat = (window as typeof window & { simpleChat?: { messageLimit?: number } }).simpleChat;
+    if (simpleChat && typeof simpleChat.messageLimit === 'number') {
+      return simpleChat.messageLimit;
+    }
+    return 24000;
+  });
+};
+
+const startConversationFromSetup = async (page: Page, topic: string) => {
+  await page.goto('/setup');
+
+  const agentCards = page.locator('.agent-card');
+  await expect(agentCards.first()).toBeVisible();
+  await agentCards.nth(0).locator('input.agent-checkbox').check();
+  await agentCards.nth(1).locator('input.agent-checkbox').check();
+
+  await page.locator('.mode-card').first().click();
+  await page.locator('#topic').fill(topic);
+
+  await Promise.all([
+    page.waitForResponse('**/api/start_session'),
+    page.locator('#start-chat-btn').click(),
+  ]);
+
+  await expect(page.locator('#chat-input')).toBeVisible();
+};
+
+test.describe('Token limit safeguards', () => {
+  test('warns and trims when the message exceeds the configured limit', async ({ page, mockedLetta }) => {
+    await mockedLetta.reset();
+    await startConversationFromSetup(page, 'Token limit regression check');
+
+    const limit = await getCharacterLimit(page);
+    const overflowAmount = 512;
+    const longMessage = 'A'.repeat(limit + overflowAmount) + ' -- trimmed check';
+
+    await page.fill('#chat-input', longMessage);
+    await page.click('#send-button');
+
+    const banner = page.locator('#token-limit-banner');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText('Message trimmed');
+    await expect(page.locator('#show-trimmed-full')).toBeEnabled();
+
+    const messageContent = page.locator('.message.user .message-content').last();
+    await expect(messageContent).toContainText(longMessage.slice(0, 100));
+
+    const trimmedText = await messageContent.evaluate((element) => element.textContent ?? '');
+    expect(trimmedText.length).toBe(limit);
+    expect(trimmedText).toBe(longMessage.slice(0, limit));
+
+    await page.click('#show-trimmed-full');
+
+    const modal = page.locator('#trimmedMessageModal');
+    await expect(modal).toBeVisible();
+
+    const fullMessage = await modal.locator('#trimmed-message-full').evaluate((element) => element.textContent ?? '');
+    expect(fullMessage.length).toBe(longMessage.length);
+    expect(fullMessage.slice(0, 120)).toBe(longMessage.slice(0, 120));
+    expect(fullMessage.slice(-120)).toBe(longMessage.slice(-120));
+
+    const sentCount = await modal.locator('#trimmed-message-count').innerText();
+    const numericSentCount = Number(sentCount.replace(/[^0-9]/g, ''));
+    expect(numericSentCount).toBe(limit);
+
+    await page.evaluate(() => {
+      const modalElement = document.getElementById('trimmedMessageModal');
+      if (!modalElement) {
+        return;
+      }
+      const bootstrap = (window as typeof window & { bootstrap?: { Modal?: { getOrCreateInstance?: (element: Element) => { hide: () => void } } } }).bootstrap;
+      bootstrap?.Modal?.getOrCreateInstance?.(modalElement)?.hide();
+      modalElement.classList.remove('show');
+      modalElement.style.display = 'none';
+      modalElement.setAttribute('aria-hidden', 'true');
+    });
+
+    const secondMessage = 'B'.repeat(limit + Math.floor(overflowAmount / 2)) + ' -- follow up';
+    await page.fill('#chat-input', secondMessage);
+    await page.click('#send-button');
+
+    await page.waitForFunction(() => {
+      const nodes = document.querySelectorAll('.message.user .message-content');
+      return nodes.length >= 2;
+    });
+
+    await page.click('#show-trimmed-full');
+
+    await expect(modal).toBeVisible();
+
+    const secondFullMessage = await modal.locator('#trimmed-message-full').evaluate((element) => element.textContent ?? '');
+    expect(secondFullMessage.length).toBe(secondMessage.length);
+    expect(secondFullMessage.slice(0, 120)).toBe(secondMessage.slice(0, 120));
+    expect(secondFullMessage.slice(-120)).toBe(secondMessage.slice(-120));
+
+    await page.evaluate(() => {
+      const modalElement = document.getElementById('trimmedMessageModal');
+      if (!modalElement) {
+        return;
+      }
+      const bootstrap = (window as typeof window & { bootstrap?: { Modal?: { getOrCreateInstance?: (element: Element) => { hide: () => void } } } }).bootstrap;
+      bootstrap?.Modal?.getOrCreateInstance?.(modalElement)?.hide();
+      modalElement.classList.remove('show');
+      modalElement.style.display = 'none';
+      modalElement.setAttribute('aria-hidden', 'true');
+    });
+
+    const latestContent = await page.locator('.message.user .message-content').last().evaluate((element) => element.textContent ?? '');
+    expect(latestContent.length).toBe(limit);
+    expect(latestContent).toBe(secondMessage.slice(0, limit));
+  });
+
+  test('allows messages exactly at the limit without trimming or warnings', async ({ page, mockedLetta }) => {
+    await mockedLetta.reset();
+    await startConversationFromSetup(page, 'Token limit boundary');
+
+    const limit = await getCharacterLimit(page);
+    const exactMessage = 'C'.repeat(limit);
+
+    await page.fill('#chat-input', exactMessage);
+    await page.click('#send-button');
+
+    const banner = page.locator('#token-limit-banner');
+    await expect(banner).toBeHidden();
+    await expect(page.locator('#show-trimmed-full')).toBeDisabled();
+
+    const messageContent = page.locator('.message.user .message-content').last();
+    await expect(messageContent).toContainText(exactMessage.slice(0, 100));
+
+    const renderedText = await messageContent.evaluate((element) => element.textContent ?? '');
+    expect(renderedText.length).toBe(limit);
+    expect(renderedText).toBe(exactMessage);
+
+    const trimmedState = await page.evaluate(() => {
+      const chat = (window as typeof window & { simpleChat?: { lastTrimmedMessage?: unknown } }).simpleChat;
+      return chat?.lastTrimmedMessage ?? null;
+    });
+    expect(trimmedState).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add a visible token-limit banner with controls to review or dismiss trimmed chat messages
- update the SimpleChat client logic to enforce a configurable character cap, retain the full message, and present it in a modal
- create a Playwright e2e test that sends oversized input and verifies UI warnings, trimming, and stored content

## Testing
- npx playwright test tests/e2e/token-limits.spec.ts

------
https://chatgpt.com/codex/tasks/task_b_68d57c3e00988332821d61cd58eaf1b1