### PR TITLE
Add chat accessibility shortcuts and tests

### DIFF
--- a/swarms-web/templates/chat.html
+++ b/swarms-web/templates/chat.html
@@ -49,6 +49,19 @@
                 </div>
             </div>
 
+            <div class="filter-toolbar border-bottom bg-light-subtle px-3 py-2">
+                <label for="message-filter" class="form-label visually-hidden">Filter messages</label>
+                <div class="input-group input-group-sm">
+                    <span class="input-group-text" id="message-filter-icon">
+                        <i class="bi bi-funnel" aria-hidden="true"></i>
+                    </span>
+                    <input type="search" id="message-filter" class="form-control"
+                           placeholder="Filter messages (press &ldquo;f&rdquo; to focus)"
+                           aria-label="Filter messages" aria-describedby="message-filter-icon"
+                           tabindex="1">
+                </div>
+            </div>
+
             <!-- Messages Area -->
             <div class="card-body p-0 position-relative">
                 <div id="chat-messages" class="chat-messages">
@@ -81,14 +94,18 @@
                     <div class="input-group">
                         <div class="input-group-prepend">
                             <button class="btn btn-outline-secondary" type="button" id="attach-button"
-                                    title="Attach files" style="border-top-right-radius: 0; border-bottom-right-radius: 0;">
+                                    title="Attach files" aria-label="Attach files"
+                                    style="border-top-right-radius: 0; border-bottom-right-radius: 0;">
                                 <i class="bi bi-paperclip"></i>
                             </button>
                         </div>
+                        <label for="chat-input" class="visually-hidden">Message composer</label>
                         <textarea id="chat-input" class="form-control chat-input"
                                   placeholder="Type your message... (Enter to send, Shift+Enter for new line)"
+                                  aria-label="Message composer" tabindex="2"
                                   rows="2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;"></textarea>
-                        <button class="btn btn-primary" type="button" id="send-button">
+                        <button class="btn btn-primary" type="button" id="send-button"
+                                aria-label="Send message" tabindex="3">
                             <i class="bi bi-send"></i>
                         </button>
                     </div>
@@ -194,7 +211,8 @@
                     <div class="card-body">
                         <div class="d-grid gap-2">
                             <button type="button" class="btn btn-outline-primary btn-sm secretary-command"
-                                    data-command="/export minutes">
+                                    data-command="/export minutes" id="export-minutes-button"
+                                    aria-label="Export board minutes" tabindex="4">
                                 <i class="bi bi-file-earmark-text"></i> Board Minutes
                             </button>
                             <button type="button" class="btn btn-outline-primary btn-sm secretary-command"
@@ -283,6 +301,7 @@ class SimpleChat {
         this.isConnected = false;
         this.agents = [];
         this.pendingAttachments = []; // Store uploaded attachments before sending
+        this.currentFilterText = '';
         this.exportLabels = {
             formal: 'Formal Minutes',
             casual: 'Casual Notes',
@@ -436,6 +455,7 @@ class SimpleChat {
         const sendButton = document.getElementById('send-button');
         const attachButton = document.getElementById('attach-button');
         const fileInput = document.getElementById('file-input');
+        const filterInput = document.getElementById('message-filter');
 
         if (chatInput && sendButton) {
             // Handle Enter key
@@ -455,6 +475,15 @@ class SimpleChat {
             chatInput.addEventListener('input', function() {
                 this.style.height = 'auto';
                 this.style.height = Math.min(this.scrollHeight, 120) + 'px';
+            });
+        }
+
+        if (filterInput) {
+            filterInput.addEventListener('input', (event) => {
+                const target = event.target;
+                const value = typeof target?.value === 'string' ? target.value : '';
+                this.currentFilterText = value.trim().toLowerCase();
+                this.applyMessageFilter();
             });
         }
 
@@ -504,6 +533,47 @@ class SimpleChat {
             console.log('Joining session:', this.sessionId);
             this.socket.emit('join_session', { session_id: this.sessionId });
         }
+    }
+
+    focusChatInput() {
+        const chatInput = document.getElementById('chat-input');
+        if (chatInput) {
+            chatInput.focus();
+        }
+    }
+
+    focusFilterInput() {
+        const filterInput = document.getElementById('message-filter');
+        if (filterInput) {
+            filterInput.focus();
+            if (typeof filterInput.select === 'function') {
+                filterInput.select();
+            }
+        }
+    }
+
+    applyMessageFilter() {
+        const messagesContainer = document.getElementById('chat-messages');
+        if (!messagesContainer) {
+            return;
+        }
+
+        const normalizedFilter = this.currentFilterText;
+        const messages = messagesContainer.querySelectorAll('.message');
+
+        messages.forEach((message) => {
+            const element = message;
+            const text = (element.textContent || '').toLowerCase();
+            const shouldShow = !normalizedFilter || text.includes(normalizedFilter);
+
+            if (shouldShow) {
+                element.removeAttribute('aria-hidden');
+                element.style.removeProperty('display');
+            } else {
+                element.setAttribute('aria-hidden', 'true');
+                element.style.display = 'none';
+            }
+        });
     }
 
     startChat(topic) {
@@ -739,6 +809,7 @@ class SimpleChat {
         `;
 
         messagesContainer.appendChild(messageElement);
+        this.applyMessageFilter();
         messagesContainer.scrollTop = messagesContainer.scrollHeight;
 
         // Show agent scores container when agents respond
@@ -1192,22 +1263,58 @@ document.addEventListener('DOMContentLoaded', () => {
     window.simpleChat = new SimpleChat();
 });
 
-// Keyboard shortcuts
-document.addEventListener('keydown', (e) => {
-    // Ctrl/Cmd + Enter to send message
-    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-        const sendButton = document.getElementById('send-button');
-        if (sendButton) {
-            sendButton.click();
-        }
+const isTextEntryTarget = (target) => {
+    if (!target) {
+        return false;
     }
 
-    // Escape to focus input
-    if (e.key === 'Escape') {
-        const chatInput = document.getElementById('chat-input');
-        if (chatInput) {
-            chatInput.focus();
+    const element = target instanceof HTMLElement ? target : null;
+    if (!element) {
+        return false;
+    }
+
+    const tagName = element.tagName;
+    if (tagName === 'INPUT' || tagName === 'TEXTAREA') {
+        return true;
+    }
+
+    return element.isContentEditable === true;
+};
+
+// Keyboard shortcuts
+document.addEventListener('keydown', (e) => {
+    const simpleChat = window.simpleChat;
+    const typingTarget = isTextEntryTarget(e.target);
+
+    // Ctrl/Cmd + Enter to send message
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+        e.preventDefault();
+        if (simpleChat && typeof simpleChat.sendMessage === 'function') {
+            simpleChat.sendMessage();
         }
+        return;
+    }
+
+    if (e.key === 'Escape') {
+        simpleChat?.focusChatInput();
+        return;
+    }
+
+    if (!simpleChat) {
+        return;
+    }
+
+    if (!e.ctrlKey && !e.metaKey && !e.altKey && e.key.toLowerCase() === 'f' && !typingTarget) {
+        e.preventDefault();
+        simpleChat.focusFilterInput();
+        return;
+    }
+
+    const isHelpShortcut = (!e.ctrlKey && !e.metaKey && (e.key === '?' || (e.key === '/' && e.shiftKey))) && !typingTarget;
+    if (isHelpShortcut) {
+        e.preventDefault();
+        simpleChat.sendMessage('/help');
+        simpleChat.focusChatInput();
     }
 });
 </script>

--- a/swarms-web/templates/chat.html
+++ b/swarms-web/templates/chat.html
@@ -57,8 +57,7 @@
                     </span>
                     <input type="search" id="message-filter" class="form-control"
                            placeholder="Filter messages (press &ldquo;f&rdquo; to focus)"
-                           aria-label="Filter messages" aria-describedby="message-filter-icon"
-                           tabindex="1">
+                           aria-label="Filter messages" aria-describedby="message-filter-icon">
                 </div>
             </div>
 
@@ -102,10 +101,10 @@
                         <label for="chat-input" class="visually-hidden">Message composer</label>
                         <textarea id="chat-input" class="form-control chat-input"
                                   placeholder="Type your message... (Enter to send, Shift+Enter for new line)"
-                                  aria-label="Message composer" tabindex="2"
+                                  aria-label="Message composer"
                                   rows="2" style="border-top-left-radius: 0; border-bottom-left-radius: 0;"></textarea>
                         <button class="btn btn-primary" type="button" id="send-button"
-                                aria-label="Send message" tabindex="3">
+                                aria-label="Send message">
                             <i class="bi bi-send"></i>
                         </button>
                     </div>
@@ -212,7 +211,7 @@
                         <div class="d-grid gap-2">
                             <button type="button" class="btn btn-outline-primary btn-sm secretary-command"
                                     data-command="/export minutes" id="export-minutes-button"
-                                    aria-label="Export board minutes" tabindex="4">
+                                    aria-label="Export board minutes">
                                 <i class="bi bi-file-earmark-text"></i> Board Minutes
                             </button>
                             <button type="button" class="btn btn-outline-primary btn-sm secretary-command"

--- a/swarms-web/tests/e2e/conversation.spec.ts
+++ b/swarms-web/tests/e2e/conversation.spec.ts
@@ -975,6 +975,7 @@ test('should enforce accessible focus order and aria labels for chat controls', 
   await startConversation(page, 'Accessibility focus order');
 
   const filterInput = page.locator('#message-filter');
+  const attachButton = page.locator('#attach-button');
   const messageInput = page.locator('#chat-input');
   const sendButton = page.locator('#send-button');
   const exportButton = page.locator('#export-minutes-button');
@@ -984,15 +985,16 @@ test('should enforce accessible focus order and aria labels for chat controls', 
   await expect(sendButton).toHaveAttribute('aria-label', 'Send message');
   await expect(exportButton).toHaveAttribute('aria-label', 'Export board minutes');
 
-  await page.evaluate(() => {
-    const active = document.activeElement as HTMLElement | null;
-    if (active && typeof active.blur === 'function') {
-      active.blur();
-    }
-  });
+  await expect(filterInput).not.toHaveAttribute('tabindex', /[1-9]+/);
+  await expect(messageInput).not.toHaveAttribute('tabindex', /[1-9]+/);
+  await expect(sendButton).not.toHaveAttribute('tabindex', /[1-9]+/);
+  await expect(exportButton).not.toHaveAttribute('tabindex', /[1-9]+/);
+
+  await filterInput.focus();
+  await expect(filterInput).toBeFocused();
 
   await page.keyboard.press('Tab');
-  await expect(filterInput).toBeFocused();
+  await expect(attachButton).toBeFocused();
 
   await page.keyboard.press('Tab');
   await expect(messageInput).toBeFocused();
@@ -1000,7 +1002,7 @@ test('should enforce accessible focus order and aria labels for chat controls', 
   await page.keyboard.press('Tab');
   await expect(sendButton).toBeFocused();
 
-  await page.keyboard.press('Tab');
+  await exportButton.focus();
   await expect(exportButton).toBeFocused();
 });
 


### PR DESCRIPTION
## Summary
- add a message filter toolbar with explicit aria labels for chat controls
- update the chat client to support keyboard shortcuts and filter-based message visibility
- extend the conversation Playwright suite with focus order and shortcut coverage

## Testing
- `npx playwright test tests/e2e/conversation.spec.ts`


------
https://chatgpt.com/codex/tasks/task_b_68d57c95a35083328b69d7ab2ace1a4f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Client-side message filtering with a filter toolbar and search input; filters auto-apply to new messages.
  - Keyboard shortcuts: Ctrl/Cmd+Enter to send, Esc to focus composer, “f” to focus filter, Shift+/? (or /?) to open help and focus input.

- Accessibility
  - Added ARIA labels and visually-hidden labels for chat controls.
  - Improved focus management and tab order for keyboard navigation.

- Tests
  - End-to-end tests for accessibility, focus order, keyboard shortcuts, and help flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->